### PR TITLE
Fix format check for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           node-version: '21.x'
       - run: yarn install
-      - run: yarn format
       - run: yarn format:check
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix format check to remove the yarn format before the check

<img width="1110" alt="Screenshot 2024-11-12 at 7 26 30 AM" src="https://github.com/user-attachments/assets/613bedf5-1fcd-4b28-9c36-41a7545d31e2">
